### PR TITLE
@Transactional 自调用事务不生效问题

### DIFF
--- a/app/src/main/java/interview/guide/modules/knowledgebase/service/KnowledgeBaseCountService.java
+++ b/app/src/main/java/interview/guide/modules/knowledgebase/service/KnowledgeBaseCountService.java
@@ -1,0 +1,34 @@
+package interview.guide.modules.knowledgebase.service;
+
+import interview.guide.common.exception.BusinessException;
+import interview.guide.common.exception.ErrorCode;
+import interview.guide.modules.knowledgebase.model.KnowledgeBaseEntity;
+import interview.guide.modules.knowledgebase.repository.KnowledgeBaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 知识库计数服务
+ */
+@Service
+@RequiredArgsConstructor
+public class KnowledgeBaseCountService {
+
+    private final KnowledgeBaseRepository knowledgeBaseRepository;
+
+    /**
+     * 批量更新知识库问题计数
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public void updateQuestionCounts(List<Long> knowledgeBaseIds) {
+        for (Long kbId : knowledgeBaseIds) {
+            KnowledgeBaseEntity kb = knowledgeBaseRepository.findById(kbId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "知识库不存在: " + kbId));
+            kb.incrementQuestionCount();
+            knowledgeBaseRepository.save(kb);
+        }
+    }
+}

--- a/app/src/main/java/interview/guide/modules/knowledgebase/service/KnowledgeBaseQueryService.java
+++ b/app/src/main/java/interview/guide/modules/knowledgebase/service/KnowledgeBaseQueryService.java
@@ -2,10 +2,8 @@ package interview.guide.modules.knowledgebase.service;
 
 import interview.guide.common.exception.BusinessException;
 import interview.guide.common.exception.ErrorCode;
-import interview.guide.modules.knowledgebase.model.KnowledgeBaseEntity;
 import interview.guide.modules.knowledgebase.model.QueryRequest;
 import interview.guide.modules.knowledgebase.model.QueryResponse;
-import interview.guide.modules.knowledgebase.repository.KnowledgeBaseRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.prompt.PromptTemplate;
@@ -13,7 +11,6 @@ import org.springframework.ai.document.Document;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 
 import java.io.IOException;
@@ -30,32 +27,32 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class KnowledgeBaseQueryService {
-    
+
     private final ChatClient chatClient;
-    private final KnowledgeBaseRepository knowledgeBaseRepository;
     private final KnowledgeBaseVectorService vectorService;
     private final KnowledgeBaseListService listService;
+    private final KnowledgeBaseCountService countService;
     private final PromptTemplate systemPromptTemplate;
     private final PromptTemplate userPromptTemplate;
-    
+
     public KnowledgeBaseQueryService(
             ChatClient.Builder chatClientBuilder,
-            KnowledgeBaseRepository knowledgeBaseRepository,
             KnowledgeBaseVectorService vectorService,
             KnowledgeBaseListService listService,
+            KnowledgeBaseCountService countService,
             @Value("classpath:prompts/knowledgebase-query-system.st") Resource systemPromptResource,
             @Value("classpath:prompts/knowledgebase-query-user.st") Resource userPromptResource) throws IOException {
         this.chatClient = chatClientBuilder.build();
-        this.knowledgeBaseRepository = knowledgeBaseRepository;
         this.vectorService = vectorService;
         this.listService = listService;
+        this.countService = countService;
         this.systemPromptTemplate = new PromptTemplate(systemPromptResource.getContentAsString(StandardCharsets.UTF_8));
         this.userPromptTemplate = new PromptTemplate(userPromptResource.getContentAsString(StandardCharsets.UTF_8));
     }
-    
+
     /**
      * 基于单个知识库回答用户问题
-     * 
+     *
      * @param knowledgeBaseId 知识库ID
      * @param question 用户问题
      * @return AI回答
@@ -63,62 +60,62 @@ public class KnowledgeBaseQueryService {
     public String answerQuestion(Long knowledgeBaseId, String question) {
         return answerQuestion(List.of(knowledgeBaseId), question);
     }
-    
+
     /**
      * 基于多个知识库回答用户问题（RAG）
-     * 
+     *
      * @param knowledgeBaseIds 知识库ID列表
      * @param question 用户问题
      * @return AI回答
      */
     public String answerQuestion(List<Long> knowledgeBaseIds, String question) {
         log.info("收到知识库提问: kbIds={}, question={}", knowledgeBaseIds, question);
-        
+
         // 1. 验证知识库是否存在并更新问题计数（合并数据库操作）
-        updateQuestionCounts(knowledgeBaseIds);
-        
+        countService.updateQuestionCounts(knowledgeBaseIds);
+
         // 2. 使用向量搜索检索相关文档（RAG）
         List<Document> relevantDocs = vectorService.similaritySearch(question, knowledgeBaseIds, 5);
-        
+
         if (relevantDocs.isEmpty()) {
             return "抱歉，在选定的知识库中没有找到相关信息。请尝试调整问题或选择其他知识库。";
         }
-        
+
         // 3. 构建上下文（合并检索到的文档）
         String context = relevantDocs.stream()
-            .map(Document::getText)
-            .collect(Collectors.joining("\n\n---\n\n"));
-        
+                .map(Document::getText)
+                .collect(Collectors.joining("\n\n---\n\n"));
+
         log.debug("检索到 {} 个相关文档片段", relevantDocs.size());
-        
+
         // 4. 构建提示词
         String systemPrompt = buildSystemPrompt();
         String userPrompt = buildUserPrompt(context, question, knowledgeBaseIds);
-        
+
         try {
             // 5. 调用AI生成回答
             String answer = chatClient.prompt()
-                .system(systemPrompt)
-                .user(userPrompt)
-                .call()
-                .content();
-            
+                    .system(systemPrompt)
+                    .user(userPrompt)
+                    .call()
+                    .content();
+
             log.info("知识库问答完成: kbIds={}", knowledgeBaseIds);
             return answer;
-            
+
         } catch (Exception e) {
             log.error("知识库问答失败: {}", e.getMessage(), e);
             throw new BusinessException(ErrorCode.KNOWLEDGE_BASE_QUERY_FAILED, "知识库查询失败：" + e.getMessage());
         }
     }
-    
+
     /**
      * 构建系统提示词
      */
     private String buildSystemPrompt() {
         return systemPromptTemplate.render();
     }
-    
+
     /**
      * 构建用户提示词
      */
@@ -128,89 +125,76 @@ public class KnowledgeBaseQueryService {
         variables.put("question", question);
         return userPromptTemplate.render(variables);
     }
-    
+
     /**
      * 查询知识库并返回完整响应
      */
     public QueryResponse queryKnowledgeBase(QueryRequest request) {
         String answer = answerQuestion(request.knowledgeBaseIds(), request.question());
-        
+
         // 获取知识库名称（多个知识库用逗号分隔）
         List<String> kbNames = listService.getKnowledgeBaseNames(request.knowledgeBaseIds());
         String kbNamesStr = String.join("、", kbNames);
-        
+
         // 使用第一个知识库ID作为主要标识（兼容前端）
         Long primaryKbId = request.knowledgeBaseIds().get(0);
-        
+
         return new QueryResponse(answer, primaryKbId, kbNamesStr);
     }
-    
+
     /**
      * 流式查询知识库（SSE）
-     * 
+     *
      * @param knowledgeBaseIds 知识库ID列表
      * @param question 用户问题
      * @return 流式响应
      */
     public Flux<String> answerQuestionStream(List<Long> knowledgeBaseIds, String question) {
         log.info("收到知识库流式提问: kbIds={}, question={}", knowledgeBaseIds, question);
-        
+
         try {
             // 1. 验证知识库是否存在并更新问题计数
-            updateQuestionCounts(knowledgeBaseIds);
-            
+            countService.updateQuestionCounts(knowledgeBaseIds);
+
             // 2. 使用向量搜索检索相关文档
             List<Document> relevantDocs = vectorService.similaritySearch(question, knowledgeBaseIds, 5);
-            
+
             if (relevantDocs.isEmpty()) {
                 return Flux.just("抱歉，在选定的知识库中没有找到相关信息。请尝试调整问题或选择其他知识库。");
             }
-            
+
             // 3. 构建上下文
             String context = relevantDocs.stream()
-                .map(Document::getText)
-                .collect(Collectors.joining("\n\n---\n\n"));
-            
+                    .map(Document::getText)
+                    .collect(Collectors.joining("\n\n---\n\n"));
+
             log.debug("检索到 {} 个相关文档片段", relevantDocs.size());
-            
+
             // 4. 构建提示词
             String systemPrompt = buildSystemPrompt();
             String userPrompt = buildUserPrompt(context, question, knowledgeBaseIds);
-            
+
             // 5. 流式调用AI生成回答
             Flux<String> responseFlux = chatClient.prompt()
-                .system(systemPrompt)
-                .user(userPrompt)
-                .stream()
-                .content();
-            
+                    .system(systemPrompt)
+                    .user(userPrompt)
+                    .stream()
+                    .content();
+
             log.info("开始流式输出知识库回答: kbIds={}", knowledgeBaseIds);
-            
+
             return responseFlux
-                .doOnComplete(() -> log.info("流式输出完成: kbIds={}", knowledgeBaseIds))
-                .onErrorResume(e -> {
-                    log.error("流式输出失败: kbIds={}, error={}", knowledgeBaseIds, e.getMessage(), e);
-                    return Flux.just("【错误】知识库查询失败：AI服务暂时不可用，请稍后重试。");
-                });
-                
+                    .doOnComplete(() -> log.info("流式输出完成: kbIds={}", knowledgeBaseIds))
+                    .onErrorResume(e -> {
+                        log.error("流式输出失败: kbIds={}, error={}", knowledgeBaseIds, e.getMessage(), e);
+                        return Flux.just("【错误】知识库查询失败：AI服务暂时不可用，请稍后重试。");
+                    });
+
         } catch (Exception e) {
             log.error("知识库流式问答失败: {}", e.getMessage(), e);
             return Flux.just("【错误】知识库查询失败：" + e.getMessage());
         }
     }
-    
-    /**
-     * 批量更新知识库问题计数（合并数据库操作）
-     */
-    @Transactional(rollbackFor = Exception.class)
-    private void updateQuestionCounts(List<Long> knowledgeBaseIds) {
-        for (Long kbId : knowledgeBaseIds) {
-            KnowledgeBaseEntity kb = knowledgeBaseRepository.findById(kbId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "知识库不存在: " + kbId));
-            kb.incrementQuestionCount();
-            knowledgeBaseRepository.save(kb);
-        }
-    }
-    
+
 }
 


### PR DESCRIPTION
Spring 的 @Transactional 是通过动态代理实现的。当你注入一个 Service 时，实际拿到的是代理对象，调用方法时会先经过代理的拦截器处理事务逻辑，但当你在同一个类内部调用方法时（this.updateQuestionCounts()），调用的是目标对象本身，不经过代理