### PR TITLE
perf: 为前端页面引入懒加载和代码分割以优化性能

### DIFF
--- a/frontend/src/components/CodeBlock.tsx
+++ b/frontend/src/components/CodeBlock.tsx
@@ -1,7 +1,11 @@
-import { useState } from 'react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { useState, lazy, Suspense } from 'react';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Check, Copy } from 'lucide-react';
+
+// Lazy load SyntaxHighlighter
+const SyntaxHighlighter = lazy(() =>
+  import('react-syntax-highlighter/dist/esm/prism').then(module => ({ default: module.default }))
+);
 
 interface CodeBlockProps {
   language?: string;
@@ -51,23 +55,29 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
       </div>
 
       {/* 代码内容 */}
-      <SyntaxHighlighter
-        language={language || 'text'}
-        style={oneDark}
-        customStyle={{
-          margin: 0,
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-          borderBottomLeftRadius: '0.75rem',
-          borderBottomRightRadius: '0.75rem',
-          fontSize: '0.875rem',
-          lineHeight: '1.5',
-        }}
-        showLineNumbers={code.split('\n').length > 3}
-        wrapLines
-      >
-        {code}
-      </SyntaxHighlighter>
+      <div className="bg-[#282c34] rounded-b-xl text-sm leading-6">
+        <Suspense fallback={
+          <div className="p-4 text-slate-400 font-mono text-xs">Loading code...</div>
+        }>
+          <SyntaxHighlighter
+            language={language || 'text'}
+            style={oneDark}
+            customStyle={{
+              margin: 0,
+              borderTopLeftRadius: 0,
+              borderTopRightRadius: 0,
+              borderBottomLeftRadius: '0.75rem',
+              borderBottomRightRadius: '0.75rem',
+              fontSize: '0.875rem',
+              lineHeight: '1.5',
+            }}
+            showLineNumbers={code.split('\n').length > 3}
+            wrapLines
+          >
+            {code}
+          </SyntaxHighlighter>
+        </Suspense>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/InterviewChatPanel.tsx
+++ b/frontend/src/components/InterviewChatPanel.tsx
@@ -1,7 +1,7 @@
-import {useEffect, useMemo, useRef} from 'react';
-import {motion} from 'framer-motion';
-import {Virtuoso, type VirtuosoHandle} from 'react-virtuoso';
-import type {InterviewQuestion, InterviewSession} from '../types/interview';
+import { useMemo, useRef } from 'react';
+import { motion } from 'framer-motion';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import type { InterviewQuestion, InterviewSession } from '../types/interview';
 import {
   Send,
   User
@@ -43,7 +43,7 @@ export default function InterviewChatPanel({
   onShowCompleteConfirm
 }: InterviewChatPanelProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
-  
+
   const progress = useMemo(() => {
     if (!session || !currentQuestion) return 0;
     return ((currentQuestion.questionIndex + 1) / session.totalQuestions) * 100;
@@ -114,7 +114,7 @@ export default function InterviewChatPanel({
               >
                 {isSubmitting ? (
                   <>
-                    <motion.div 
+                    <motion.div
                       className="w-4 h-4 border-2 border-white border-t-transparent rounded-full"
                       animate={{ rotate: 360 }}
                       transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
@@ -187,8 +187,8 @@ function MessageBubble({ message }: { message: Message }) {
       </div>
       <div className="w-8 h-8 bg-slate-200 rounded-full flex items-center justify-center flex-shrink-0">
         <svg className="w-4 h-4 text-slate-600" viewBox="0 0 24 24" fill="none">
-          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          <circle cx="12" cy="7" r="4" stroke="currentColor" strokeWidth="2"/>
+          <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          <circle cx="12" cy="7" r="4" stroke="currentColor" strokeWidth="2" />
         </svg>
       </div>
     </motion.div>

--- a/frontend/src/pages/KnowledgeBaseQueryPage.tsx
+++ b/frontend/src/pages/KnowledgeBaseQueryPage.tsx
@@ -1,11 +1,11 @@
-import {useEffect, useState, useRef, useTransition, useMemo} from 'react';
-import {motion, AnimatePresence} from 'framer-motion';
+import { useEffect, useState, useRef, useTransition, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import {Virtuoso, type VirtuosoHandle} from 'react-virtuoso';
-import {knowledgeBaseApi, type KnowledgeBaseItem, type SortOption} from '../api/knowledgebase';
-import {ragChatApi, type RagChatSessionListItem} from '../api/ragChat';
-import {formatDateOnly} from '../utils/date';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import { knowledgeBaseApi, type KnowledgeBaseItem, type SortOption } from '../api/knowledgebase';
+import { ragChatApi, type RagChatSessionListItem } from '../api/ragChat';
+import { formatDateOnly } from '../utils/date';
 import DeleteConfirmDialog from '../components/DeleteConfirmDialog';
 import CodeBlock from '../components/CodeBlock';
 import {
@@ -66,11 +66,9 @@ export default function KnowledgeBaseQueryPage({ onBack, onUpload }: KnowledgeBa
 
   // refs
   const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const isUserScrollingRef = useRef(false);
   const rafRef = useRef<number>();
-  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
 
   useEffect(() => {
     loadKnowledgeBases();
@@ -432,11 +430,10 @@ export default function KnowledgeBaseQueryPage({ onBack, onUpload }: KnowledgeBa
                     <div
                       key={session.id}
                       onClick={() => handleLoadSession(session.id)}
-                      className={`p-3 rounded-lg cursor-pointer transition-all group ${
-                        currentSessionId === session.id
-                          ? 'bg-primary-50 border border-primary-500'
-                          : 'bg-slate-50 hover:bg-slate-100 border border-transparent'
-                      } ${session.isPinned ? 'border-l-4 border-l-primary-500' : ''}`}
+                      className={`p-3 rounded-lg cursor-pointer transition-all group ${currentSessionId === session.id
+                        ? 'bg-primary-50 border border-primary-500'
+                        : 'bg-slate-50 hover:bg-slate-100 border border-transparent'
+                        } ${session.isPinned ? 'border-l-4 border-l-primary-500' : ''}`}
                     >
                       <div className="flex items-start justify-between gap-2">
                         <div className="flex-1 min-w-0">
@@ -453,11 +450,10 @@ export default function KnowledgeBaseQueryPage({ onBack, onUpload }: KnowledgeBa
                         <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-all">
                           <button
                             onClick={(e) => handleTogglePin(session.id, e)}
-                            className={`p-1 rounded transition-colors ${
-                              session.isPinned
-                                ? 'text-primary-500 hover:text-primary-600'
-                                : 'text-slate-400 hover:text-primary-500'
-                            }`}
+                            className={`p-1 rounded transition-colors ${session.isPinned
+                              ? 'text-primary-500 hover:text-primary-600'
+                              : 'text-slate-400 hover:text-primary-500'
+                              }`}
                             title={session.isPinned ? '取消置顶' : '置顶'}
                           >
                             <Pin className={`w-4 h-4 ${session.isPinned ? 'fill-primary-500' : ''}`} />
@@ -538,11 +534,10 @@ export default function KnowledgeBaseQueryPage({ onBack, onUpload }: KnowledgeBa
                             className={`flex ${msg.type === 'user' ? 'justify-end' : 'justify-start'}`}
                           >
                             <div
-                              className={`max-w-[85%] rounded-2xl p-4 shadow-sm ${
-                                msg.type === 'user'
-                                  ? 'bg-primary-600 text-white'
-                                  : 'bg-white border border-slate-100 text-slate-800'
-                              }`}
+                              className={`max-w-[85%] rounded-2xl p-4 shadow-sm ${msg.type === 'user'
+                                ? 'bg-primary-600 text-white'
+                                : 'bg-white border border-slate-100 text-slate-800'
+                                }`}
                             >
                               {msg.type === 'user' ? (
                                 <p className="whitespace-pre-wrap leading-relaxed text-sm">{msg.content}</p>
@@ -625,7 +620,7 @@ export default function KnowledgeBaseQueryPage({ onBack, onUpload }: KnowledgeBa
               <div className="flex-1 flex items-center justify-center text-slate-400">
                 <div className="text-center">
                   <svg className="w-12 h-12 mx-auto mb-3 opacity-50" viewBox="0 0 24 24" fill="none">
-                    <path d="M21 15C21 15.5304 20.7893 16.0391 20.4142 16.4142C20.0391 16.7893 19.5304 17 19 17H7L3 21V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H19C19.5304 3 20.0391 3.21071 20.4142 3.58579C20.7893 3.96086 21 4.46957 21 5V15Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M21 15C21 15.5304 20.7893 16.0391 20.4142 16.4142C20.0391 16.7893 19.5304 17 19 17H7L3 21V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H19C19.5304 3 20.0391 3.21071 20.4142 3.58579C20.7893 3.96086 21 4.46957 21 5V15Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                   </svg>
                   <p className="text-sm">请先在右侧选择知识库</p>
                 </div>
@@ -740,11 +735,10 @@ export default function KnowledgeBaseQueryPage({ onBack, onUpload }: KnowledgeBa
                                     <div
                                       key={kb.id}
                                       onClick={() => handleToggleKb(kb.id)}
-                                      className={`p-2 rounded-lg cursor-pointer transition-all ${
-                                        selectedKbIds.has(kb.id)
-                                          ? 'bg-primary-50 border border-primary-500'
-                                          : 'bg-white hover:bg-slate-50 border border-transparent'
-                                      }`}
+                                      className={`p-2 rounded-lg cursor-pointer transition-all ${selectedKbIds.has(kb.id)
+                                        ? 'bg-primary-50 border border-primary-500'
+                                        : 'bg-white hover:bg-slate-50 border border-transparent'
+                                        }`}
                                     >
                                       <div className="flex items-center gap-2">
                                         <input

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,16 +1,29 @@
-import {defineConfig} from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+  ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'ui-vendor': ['framer-motion', 'lucide-react'],
+          'syntax-highlighter': ['react-syntax-highlighter'],
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',
         changeOrigin: true,
-      }
-    }
-  }
-})
+      },
+    },
+  },
+});


### PR DESCRIPTION
📝 摘要
针对前端应用进行了重大的性能优化。通过实施代码分割和懒加载策略，解决了首屏加载缓慢和 Bundle 体积过大的问题。

⚡ 性能提升
首屏 JS Bundle: 从 ~1.63 MB 减少到 ~47 KB (减少 97%)。
问答助手页面: 通过懒加载语法高亮库 (~640KB)，显著减轻了页面重量，实现了秒级加载。
🛠 主要变更
Vite 配置: 添加 manualChunks 将 react-vendor、ui-vendor 和 syntax-highlighter 分离为独立的缓存文件。
路由: 将 
App.tsx
 中的所有页面导入转换为带 Suspense 回退的 React.lazy()。
组件: 重构 
CodeBlock.tsx
，仅在需要时异步加载 react-syntax-highlighter，并使用精确导入路径以最小化占用。
清理: 移除了 
KnowledgeBaseQueryPage.tsx
 和 
InterviewChatPanel.tsx
 中未使用的依赖和变量。
✅ 验证
验证了构建输出体积（见评论中的截图/日志）。
测试了所有模块（上传、历史、面试、知识库）之间的导航。
验证了问答助手中的代码高亮功能正常。

附上优化前后的性能截图
优化前：
<img width="1800" height="929" alt="Snipaste_2026-01-23_17-06-18" src="https://github.com/user-attachments/assets/2f3b764c-7a42-42c1-a291-db104a07c862" />
<img width="1800" height="926" alt="Snipaste_2026-01-23_17-24-12" src="https://github.com/user-attachments/assets/c1782dc4-3774-4e80-a509-382376035702" />
优化后：
<img width="1800" height="923" alt="Snipaste_2026-01-23_17-26-45" src="https://github.com/user-attachments/assets/5be2e92d-112a-4e9d-abd3-f662783ad8ab" />
<img width="1800" height="920" alt="Snipaste_2026-01-23_17-25-45" src="https://github.com/user-attachments/assets/b5791c19-205c-443f-a0d2-c66d1b87a06d" />
部署后
<img width="1796" height="924" alt="Snipaste_2026-01-23_17-29-09" src="https://github.com/user-attachments/assets/0a4f474b-9a91-4800-883e-8c92e94c0969" />

