### PR TITLE
fix: 优化多栏布局 PDF 的解析顺序

### DIFF
--- a/app/src/main/java/interview/guide/infrastructure/file/DocumentParseService.java
+++ b/app/src/main/java/interview/guide/infrastructure/file/DocumentParseService.java
@@ -124,9 +124,10 @@ public class DocumentParseService {
         // 6. 禁用嵌入文档解析（关键：避免提取图片引用和临时文件路径）
         context.set(EmbeddedDocumentExtractor.class, new NoOpEmbeddedDocumentExtractor());
 
-        // 7. PDF 专用配置：关闭图片提取
+        // 7. PDF 专用配置：关闭图片提取，按位置排序文本
         PDFParserConfig pdfConfig = new PDFParserConfig();
         pdfConfig.setExtractInlineImages(false);
+        pdfConfig.setSortByPosition(true); // 按 x/y 坐标排序文本，改善多栏布局解析顺序
         // 注意：Tika 2.9.2 中 setExtractAnnotations 方法可能不存在，关闭图片提取已足够
         context.set(PDFParserConfig.class, pdfConfig);
 


### PR DESCRIPTION
# Pull Request 建议

## 标题
fix(resume): 修复多栏布局简历解析顺序错乱问题

## 描述

### 🐛 问题描述
在解析多栏布局的 PDF 简历时，Apache Tika 默认按照 PDF 内部的内容流顺序（Stream Order）提取文本。这导致提取出的文本顺序与视觉阅读顺序不一致，严重影响了后续的**简历评分**系统对信息的抓取精度。

#### ❌ 错误示例 (Fix 前)
对于典型的“左侧主内容 + 右侧个人信息栏”或者其他分栏布局布局，解析出的文本顺序会被打乱，例如个人信息（如名字、年龄、联系方式）排在整个文档的最末尾，导致评分 Prompt 上下文断裂：

```text
[...项目经验内容...]
[...专业技能内容...]
（原本应在开头的个人信息出现在了最后）
男/23岁/XX/26届
[Github_ID]
138xxxx8888
example@email.com
```

### 💡 解决方案
在 [DocumentParseService](file:///Users/carol/develop/interview-guide/app/src/main/java/interview/guide/infrastructure/file/DocumentParseService.java#27-164) 的 PDF 解析配置中启用了 `sortByPosition` 选项，强制按文本在页面上的视觉坐标（从上到下、从左到右）进行排序：

```java
pdfConfig.setSortByPosition(true);
```

### ✅ 效果验证 (Fix 后)
解析顺序恢复正常，个人信息正确出现在文档开头，确保了 LLM 可以正确关联候选人信息与后续经历：

```text
[候选人姓名]-[职位]
男/23岁/XX/26届
[Github_ID]
138xxxx8888
...
[...项目经验内容...]
```

### 关联提交
- `fix: 优化多栏布局 PDF 的解析顺序`
