### PR TITLE
fix: 编辑面试弹窗中增加删除按钮，无需返回列表即可删除

### DIFF
--- a/frontend/src/components/interviewschedule/InterviewFormModal.tsx
+++ b/frontend/src/components/interviewschedule/InterviewFormModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { X, ChevronRight, ChevronLeft, AlertCircle, CheckCircle } from 'lucide-react';
+import { X, ChevronRight, ChevronLeft, AlertCircle, CheckCircle, Trash2 } from 'lucide-react';
 import type { InterviewFormData, ParseResponse, InterviewType } from '../../types/interviewSchedule';
 import { interviewScheduleApi } from '../../api/interviewSchedule';
 import dayjs from 'dayjs';
@@ -11,6 +11,7 @@ interface InterviewFormModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (data: InterviewFormData) => Promise<void>;
+  onDelete?: (id: number) => void;
   initialData?: InterviewFormData;
   mode: 'create' | 'edit';
 }
@@ -30,6 +31,7 @@ export const InterviewFormModal: React.FC<InterviewFormModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
+  onDelete,
   initialData,
   mode,
 }) => {
@@ -423,7 +425,7 @@ export const InterviewFormModal: React.FC<InterviewFormModalProps> = ({
       )}
 
       <div className="flex justify-between pt-5 gap-3">
-        {mode === 'create' && step !== 'text' && (
+        {mode === 'create' && step !== 'text' ? (
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
@@ -433,7 +435,18 @@ export const InterviewFormModal: React.FC<InterviewFormModalProps> = ({
           >
             重置
           </motion.button>
-        )}
+        ) : mode === 'edit' && onDelete && initialData?.id ? (
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            type="button"
+            onClick={() => onDelete(initialData.id!)}
+            className="px-5 py-2.5 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl font-medium flex items-center gap-2 transition-all"
+          >
+            <Trash2 className="w-4 h-4" />
+            删除
+          </motion.button>
+        ) : null}
         <div className="flex gap-3 ml-auto">
           <motion.button
             whileHover={{ scale: 1.02 }}

--- a/frontend/src/pages/InterviewSchedulePage.tsx
+++ b/frontend/src/pages/InterviewSchedulePage.tsx
@@ -200,6 +200,11 @@ export const InterviewSchedulePage: React.FC = () => {
           setSelectedInterview(null);
         }}
         onSubmit={handleFormSubmit}
+        onDelete={(id) => {
+          setIsModalOpen(false);
+          setSelectedInterview(null);
+          handleDeleteClick(id);
+        }}
         initialData={selectedInterview || undefined}
         mode={modalMode}
       />


### PR DESCRIPTION
  ## Summary
  - 编辑面试弹窗底部新增「删除」按钮，点击后弹出确认对话框，无需返回列表页即可完成删除操作
  - 复用已有的 `ConfirmDialog` 和 `handleDeleteClick` 流程，与列表页删除行为一致

  ## Changes
  - `InterviewFormModal.tsx`: 新增 `onDelete` 回调 prop，编辑模式下显示红色删除按钮
  - `InterviewSchedulePage.tsx`: 向 Modal 传入 `onDelete`，关闭弹窗后触发删除确认

<img width="1200" height="1633" alt="image" src="https://github.com/user-attachments/assets/fb51f2d6-4225-48b2-9b56-31560f31e4bc" />
