### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ PROVIDER_KIMI_MODEL=kimi-k2.6
 PROVIDER_DEEPSEEK_API_KEY=
 PROVIDER_DEEPSEEK_MODEL=deepseek-v4-flash
 
+# Atlas Cloud (https://api.atlascloud.ai/)
+PROVIDER_ATLASCLOUD_API_KEY=
+PROVIDER_ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+# PROVIDER_ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+
 # 智谱 AI / GLM (https://open.bigmodel.cn/)
 PROVIDER_GLM_API_KEY=
 PROVIDER_GLM_MODEL=glm-5

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -136,6 +136,12 @@ app:
         api-key: ${PROVIDER_DEEPSEEK_API_KEY:}
         model: ${PROVIDER_DEEPSEEK_MODEL:deepseek-v4-flash}
         supports-embedding: false
+      # Atlas Cloud（OpenAI 兼容） https://api.atlascloud.ai/
+      atlascloud:
+        base-url: ${PROVIDER_ATLASCLOUD_BASE_URL:${PROVIDER_ATLAS_CLOUD_BASE_URL:${ATLASCLOUD_BASE_URL:${ATLAS_CLOUD_BASE_URL:https://api.atlascloud.ai/v1}}}}
+        api-key: ${PROVIDER_ATLASCLOUD_API_KEY:${PROVIDER_ATLAS_CLOUD_API_KEY:${ATLASCLOUD_API_KEY:${ATLAS_CLOUD_API_KEY:}}}}
+        model: ${PROVIDER_ATLASCLOUD_MODEL:${PROVIDER_ATLAS_CLOUD_MODEL:${ATLASCLOUD_MODEL:${ATLAS_CLOUD_MODEL:deepseek-ai/deepseek-v4-pro}}}}
+        supports-embedding: false
       # 智谱 AI / GLM（OpenAI 兼容） https://open.bigmodel.cn/
       glm:
         base-url: https://open.bigmodel.cn/api/coding/paas/v4

--- a/app/src/test/java/interview/guide/common/ai/ApiPathResolverTest.java
+++ b/app/src/test/java/interview/guide/common/ai/ApiPathResolverTest.java
@@ -20,11 +20,12 @@ class ApiPathResolverTest {
     }
 
     @Test
-    @DisplayName("以 /v1 结尾（Kimi / DeepSeek / SiliconFlow / DashScope 兼容模式）返回 true")
+    @DisplayName("以 /v1 结尾（Kimi / DeepSeek / SiliconFlow / DashScope / Atlas Cloud）返回 true")
     void trailingV1() {
       assertThat(ApiPathResolver.baseUrlContainsVersion("https://api.moonshot.cn/v1")).isTrue();
       assertThat(ApiPathResolver.baseUrlContainsVersion("https://api.deepseek.com/v1")).isTrue();
       assertThat(ApiPathResolver.baseUrlContainsVersion("https://api.siliconflow.cn/v1")).isTrue();
+      assertThat(ApiPathResolver.baseUrlContainsVersion("https://api.atlascloud.ai/v1")).isTrue();
       assertThat(ApiPathResolver.baseUrlContainsVersion(
           "https://dashscope.aliyuncs.com/compatible-mode/v1")).isTrue();
     }
@@ -115,6 +116,8 @@ class ApiPathResolverTest {
     void versionedBaseUrlStaysUnchanged() {
       assertThat(ApiPathResolver.resolveVersionedBaseUrl("https://api.moonshot.cn/v1/"))
           .isEqualTo("https://api.moonshot.cn/v1");
+      assertThat(ApiPathResolver.resolveVersionedBaseUrl("https://api.atlascloud.ai/v1/"))
+          .isEqualTo("https://api.atlascloud.ai/v1");
     }
 
     @Test

--- a/app/src/test/java/interview/guide/common/ai/LlmProviderRegistryPathIntegrationTest.java
+++ b/app/src/test/java/interview/guide/common/ai/LlmProviderRegistryPathIntegrationTest.java
@@ -114,6 +114,18 @@ class LlmProviderRegistryPathIntegrationTest {
   }
 
   @Test
+  @DisplayName("Atlas Cloud 风格 /v1 base-url 不重复追加版本段")
+  void atlasCloudBaseUrlWithV1_noDoubleVersion() {
+    LlmProviderRegistry registry = buildRegistryFor("http://127.0.0.1:" + port + "/v1");
+
+    ChatClient client = registry.getChatClient("probe");
+    client.prompt("hi").call().content();
+
+    assertThat(receivedPaths).hasSize(1);
+    assertThat(receivedPaths.get(0)).isEqualTo("/v1/chat/completions");
+  }
+
+  @Test
   @DisplayName("base-url 以 /api/v3（豆包 Ark 风格）结尾时不重复版本段")
   void baseUrlWithV3_noDoubleVersion() {
     LlmProviderRegistry registry = buildRegistryFor("http://127.0.0.1:" + port + "/api/v3");

--- a/app/src/test/java/interview/guide/modules/llmprovider/service/LlmProviderConfigServiceTest.java
+++ b/app/src/test/java/interview/guide/modules/llmprovider/service/LlmProviderConfigServiceTest.java
@@ -133,6 +133,14 @@ class LlmProviderConfigServiceTest {
         }
 
         @Test
+        @DisplayName("Atlas Cloud base-url 测试连接不应重复拼接 /v1")
+        void buildConnectivityUrlsAvoidsDoubleVersionForAtlasCloud() throws Exception {
+            List<String> urls = invokeConnectivityUrls("https://api.atlascloud.ai/v1");
+
+            assertEquals(List.of("https://api.atlascloud.ai/v1/chat/completions"), urls);
+        }
+
+        @Test
         @DisplayName("测试连接请求体不再强制携带 temperature")
         void connectivityRequestBodyOmitsTemperature() throws Exception {
             Map<String, Object> body = invokeConnectivityRequestBody("kimi-latest");

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -48,6 +48,15 @@ const PROVIDER_PRESETS: Record<string, {
     ],
     supportsEmbedding: false,
   },
+  atlascloud: {
+    baseUrl: 'https://api.atlascloud.ai/v1',
+    models: [
+      { value: 'deepseek-ai/deepseek-v4-pro', label: 'DeepSeek V4 Pro — Atlas Cloud' },
+      { value: 'deepseek-ai/deepseek-v4-flash', label: 'DeepSeek V4 Flash — Atlas Cloud' },
+      { value: 'qwen/qwen3.5-flash', label: 'Qwen3.5 Flash — Atlas Cloud' },
+    ],
+    supportsEmbedding: false,
+  },
   glm: {
     baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
     models: [
@@ -915,7 +924,7 @@ export default function SettingsPage() {
                         }
                       }}
                       disabled={!!editingProvider}
-                      placeholder="例如: dashscope, deepseek, glm, kimi"
+                      placeholder="例如: dashscope, atlascloud, deepseek, glm, kimi"
                       className="w-full px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-600
                         bg-white dark:bg-slate-700 text-sm text-slate-900 dark:text-white
                         placeholder:text-slate-400 focus:outline-none focus:ring-2


### PR DESCRIPTION
## Summary
- add an `atlascloud` OpenAI-compatible provider seed with Atlas Cloud base URL/API key/model environment fallbacks
- add Atlas Cloud to the settings page provider preset list with default chat models
- cover Atlas Cloud `/v1` base URLs in provider connectivity/path tests so the runtime does not append a second `/v1`

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts` (frontend)
- `pnpm run build` (frontend; existing Browserslist/CSS minify/chunk-size warnings only)
- `python3` YAML parse for `app/src/main/resources/application.yml`
- `git diff --check` and `git diff --cached --check`
- Atlas public model catalog checks: `/api/v1/models` returned 437 models and `/v1/models` returned 121 text models; confirmed `deepseek-ai/deepseek-v4-pro`, `deepseek-ai/deepseek-v4-flash`, and `qwen/qwen3.5-flash`

## Not run
- `./gradlew :app:test --tests interview.guide.common.ai.ApiPathResolverTest --tests interview.guide.common.ai.LlmProviderRegistryPathIntegrationTest --tests interview.guide.modules.llmprovider.service.LlmProviderConfigServiceTest --no-daemon` because this local machine has no Java Runtime installed (`Unable to locate a Java Runtime`)

No README or logo changes.