### PR TITLE
feat(voice-interview): 新增语音面试上下文滑动窗口与增量摘要压缩

### DIFF
--- a/app/src/main/java/interview/guide/common/ai/LlmProviderRegistry.java
+++ b/app/src/main/java/interview/guide/common/ai/LlmProviderRegistry.java
@@ -116,6 +116,14 @@ public class LlmProviderRegistry {
     }
 
     /**
+     * 获取默认 provider 的不带 SkillsTool 的 ChatClient，用于纯粹的摘要 / 结构化文本场景。
+     * 与 {@link #getDefaultChatClient()} 的区别在于不挂 Skill 工具与记忆 Advisor，避免无关上下文干扰。
+     */
+    public ChatClient getPlainChatClient() {
+        return getPlainChatClient(resolveDefaultChatProviderId());
+    }
+
+    /**
      * Get a ChatClient for the specified provider, falling back to the default if null, blank, or
      * the legacy "default" alias.
      */

--- a/app/src/main/java/interview/guide/modules/voiceinterview/config/VoiceInterviewProperties.java
+++ b/app/src/main/java/interview/guide/modules/voiceinterview/config/VoiceInterviewProperties.java
@@ -22,6 +22,7 @@ public class VoiceInterviewProperties {
     private AudioConfig audio = new AudioConfig();
     private QwenConfig qwen = new QwenConfig();
     private OpeningConfig opening = new OpeningConfig();
+    private ContextCompressionConfig contextCompression = new ContextCompressionConfig();
 
     /**
      * 语音面试单轮面试官回复最大字符数（超出会截断到句子边界）。
@@ -161,5 +162,29 @@ public class VoiceInterviewProperties {
             "你好，我是本场面试官。先做一道算法与数据结构热身题：请你从“哈希表/堆/栈/队列/树/图”里选两个，结合一道你熟悉的题，口述“为什么选这个结构、核心步骤、时间复杂度、空间复杂度、边界条件与反例”。本场不需要写代码，重点看你的思路和取舍。";
         private String backendQuestion =
             "你好，我是本场面试官。第一个问题：请用 1 分钟介绍一个你深度参与的项目，按三点回答：业务目标、你负责的核心模块、核心技术栈。说完我会立刻追问一个关键技术决策。";
+    }
+
+    @Data
+    public static class ContextCompressionConfig {
+        /**
+         * 是否启用上下文压缩。默认关闭，保证向后兼容（关闭时行为与改前完全一致）。
+         */
+        private boolean enabled = false;
+        /**
+         * 压缩模式：NONE=不压缩；WINDOW=仅保留最近窗口原文；SUMMARY=窗口原文+早期轮次增量摘要。
+         */
+        private Mode mode = Mode.SUMMARY;
+        /**
+         * 保留的最近轮次数量（滑动窗口大小）。
+         */
+        private int windowSize = 20;
+        /**
+         * 早期轮次每越过该批次数，触发一次增量摘要合并（降低 LLM 摘要调用频率）。
+         */
+        private int summaryBatchSize = 10;
+    }
+
+    public enum Mode {
+        NONE, WINDOW, SUMMARY
     }
 }

--- a/app/src/main/java/interview/guide/modules/voiceinterview/context/VoiceContextCompressor.java
+++ b/app/src/main/java/interview/guide/modules/voiceinterview/context/VoiceContextCompressor.java
@@ -1,0 +1,160 @@
+package interview.guide.modules.voiceinterview.context;
+
+import interview.guide.common.ai.LlmProviderRegistry;
+import interview.guide.modules.voiceinterview.config.VoiceInterviewProperties;
+import interview.guide.modules.voiceinterview.model.VoiceInterviewMessageEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 语音面试上下文压缩器。
+ *
+ * <p>将全量对话历史压缩为「最近窗口原文 + 早期轮次滚动摘要」，避免长会话下
+ * 每轮把完整转录重发给 LLM 导致的 prompt token 无界增长与上下文溢出风险。
+ *
+ * <p>设计要点（详见 docs/语音面试上下文压缩_技术方案设计.md）：
+ * <ul>
+ *   <li>mode=NONE：不压缩，返回全部（默认行为，向后兼容）</li>
+ *   <li>mode=WINDOW：仅保留最近 windowSize 轮原文，更早轮次丢弃</li>
+ *   <li>mode=SUMMARY：保留最近窗口原文 + 早期轮次增量摘要（按 summaryBatchSize 触发，降低 LLM 摘要调用频率）</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class VoiceContextCompressor {
+
+    private final LlmProviderRegistry llmProviderRegistry;
+    private final VoiceInterviewProperties properties;
+
+    public VoiceContextCompressor(LlmProviderRegistry llmProviderRegistry, VoiceInterviewProperties properties) {
+        this.llmProviderRegistry = llmProviderRegistry;
+        this.properties = properties;
+    }
+
+    /**
+     * 压缩对话历史。
+     *
+     * @param turns         全部对话轮次（不含 SUMMARY 行），按 sequenceNum 升序
+     * @param cachedSummary 持久化已有的摘要（可能为 null）
+     * @param coveredTurns  已被摘要覆盖的轮次数（用于增量合并，避免重复摘要）
+     * @return 压缩结果：summary（可能为 null）、recent（保留的近期轮次）、coveredTurns、changed
+     */
+    public CompressedHistory compress(List<VoiceInterviewMessageEntity> turns,
+                                       String cachedSummary, int coveredTurns) {
+        var cfg = properties.getContextCompression();
+        // 未启用 / NONE 模式 / 未达到窗口大小：不压缩，返回全量（向后兼容）
+        if (!cfg.isEnabled() || cfg.getMode() == VoiceInterviewProperties.Mode.NONE
+                || turns.size() <= cfg.getWindowSize()) {
+            return new CompressedHistory(null, turns, turns.size(), false);
+        }
+
+        int total = turns.size();
+        int window = cfg.getWindowSize();
+        int earlyCount = total - window;
+        String summary = cachedSummary;
+        boolean changed = false;
+
+        if (cfg.getMode() == VoiceInterviewProperties.Mode.SUMMARY
+                && earlyCount > coveredTurns
+                && earlyCount - coveredTurns >= cfg.getSummaryBatchSize()) {
+            // 仅对「尚未覆盖的早期轮次」做增量摘要合并，避免每轮都调用 LLM
+            // earlyCount > coveredTurns 防御上游脏数据（如被损坏的 SUMMARY 行），避免 subList(from > to) 抛异常
+            List<String> earlyTurns = formatRecent(turns.subList(coveredTurns, earlyCount));
+            String newSummary = summarize(cachedSummary, earlyTurns);
+            if (newSummary != null && !newSummary.equals(cachedSummary)) {
+                summary = newSummary;
+                coveredTurns = earlyCount;
+                changed = true;
+            } else {
+                // 摘要未变化（或生成失败降级）：保持现状，不标记 changed，避免无谓持久化
+                summary = newSummary != null ? newSummary : cachedSummary;
+            }
+        }
+
+        List<VoiceInterviewMessageEntity> recent = turns.subList(earlyCount, total);
+        return new CompressedHistory(summary, recent, coveredTurns, changed);
+    }
+
+    /**
+     * 将实体轮次格式化为「面试官：/候选人：」文本行，与原 getHistory 的格式化逻辑保持一致。
+     */
+    public List<String> formatRecent(List<VoiceInterviewMessageEntity> turns) {
+        List<String> history = new ArrayList<>();
+        String pendingAiQuestion = null;
+        for (VoiceInterviewMessageEntity msg : turns) {
+            String aiText = VoiceInterviewMessageEntity.trimToNull(msg.getAiGeneratedText());
+            String userText = VoiceInterviewMessageEntity.trimToNull(msg.getUserRecognizedText());
+            if (pendingAiQuestion != null) {
+                history.add("面试官：" + pendingAiQuestion);
+                pendingAiQuestion = null;
+                if (userText != null) {
+                    history.add("候选人：" + userText);
+                }
+                if (aiText != null) {
+                    pendingAiQuestion = aiText;
+                }
+                continue;
+            }
+            if (aiText != null && userText != null) {
+                history.add("面试官：" + aiText);
+                history.add("候选人：" + userText);
+            } else if (aiText != null) {
+                pendingAiQuestion = aiText;
+            } else if (userText != null) {
+                history.add("候选人：" + userText);
+            }
+        }
+        if (pendingAiQuestion != null) {
+            history.add("面试官：" + pendingAiQuestion);
+        }
+        return history;
+    }
+
+    /**
+     * 将早期轮次增量合并进已有摘要。摘要生成失败则降级沿用已有摘要，不阻塞主链路。
+     */
+    private String summarize(String prevSummary, List<String> earlyTurns) {
+        if (earlyTurns == null || earlyTurns.isEmpty()) {
+            return prevSummary;
+        }
+        try {
+            String prompt = buildSummaryPrompt(prevSummary, earlyTurns);
+            // 使用不带 SkillsTool / MemoryAdvisor 的 plain client：摘要是纯文本压缩，
+            // 不应混入面试素材工具，也不应让 MemoryAdvisor 重新注入完整历史（否则抵消压缩收益）
+            String result = llmProviderRegistry.getPlainChatClient()
+                    .prompt().user(prompt).call().content();
+            return (result == null || result.isBlank()) ? prevSummary : result.trim();
+        } catch (Exception e) {
+            log.warn("上下文摘要生成失败，降级沿用已有摘要", e);
+            return prevSummary;
+        }
+    }
+
+    private String buildSummaryPrompt(String prevSummary, List<String> earlyTurns) {
+        return new StringBuilder()
+                .append("你是一个面试对话摘要器。下方是一段语音面试的「前情摘要」（可能为空）与「新增对话轮次」。\n")
+                .append("请将新增轮次合并进前情摘要，输出一段简洁、保留关键事实（候选人提到的项目/技术栈/经历/已答题点）的中文摘要，")
+                .append("不要编造未提及的内容。\n\n")
+                .append("【前情摘要】\n").append(prevSummary == null ? "(空)" : prevSummary).append("\n\n")
+                .append("【新增轮次】\n").append(String.join("\n", earlyTurns)).append("\n\n")
+                .append("【合并后摘要】")
+                .toString();
+    }
+
+    /**
+     * 压缩结果。
+     *
+     * @param summary     早期轮次的滚动摘要（mode=SUMMARY 且已触发时非 null）
+     * @param recent      保留的近期轮次实体（窗口内）
+     * @param coveredTurns 已被摘要覆盖的轮次数
+     * @param changed     摘要是否较缓存发生变化（需持久化）
+     */
+    public record CompressedHistory(String summary,
+                                     List<VoiceInterviewMessageEntity> recent,
+                                     int coveredTurns,
+                                     boolean changed) {
+    }
+}

--- a/app/src/main/java/interview/guide/modules/voiceinterview/handler/VoiceInterviewWebSocketHandler.java
+++ b/app/src/main/java/interview/guide/modules/voiceinterview/handler/VoiceInterviewWebSocketHandler.java
@@ -8,6 +8,7 @@ import interview.guide.modules.voiceinterview.dto.WebSocketSubtitleMessage;
 import interview.guide.modules.voiceinterview.model.VoiceInterviewMessageEntity;
 import interview.guide.modules.voiceinterview.model.VoiceInterviewSessionEntity;
 import interview.guide.modules.voiceinterview.config.VoiceInterviewProperties;
+import interview.guide.modules.voiceinterview.context.VoiceContextCompressor;
 import interview.guide.modules.voiceinterview.service.QwenAsrService;
 import interview.guide.modules.voiceinterview.service.QwenTtsService;
 import interview.guide.modules.voiceinterview.service.DashscopeLlmService;
@@ -61,6 +62,7 @@ public class VoiceInterviewWebSocketHandler extends TextWebSocketHandler impleme
     private final QwenTtsService ttsService;
     private final DashscopeLlmService llmService;
     private final VoiceInterviewService interviewService;
+    private final VoiceContextCompressor voiceContextCompressor;
     private final VoiceInterviewProperties voiceInterviewProperties;
     private final ObjectProvider<MeterRegistry> meterRegistryProvider;
 
@@ -1224,45 +1226,50 @@ public class VoiceInterviewWebSocketHandler extends TextWebSocketHandler impleme
     }
 
     /**
-     * Get chat history for session
-     * Load conversation history from database
+     * Get chat history for session.
+     * 加载对话历史并进行上下文压缩（滑动窗口 + 可选增量摘要），再格式化为文本行。
+     * 当 contextCompression.enabled=false 时行为与改前完全一致（返回全量格式化轮次）。
      */
     private List<String> getHistory(String sessionId) {
         try {
-            List<VoiceInterviewMessageEntity> messages = interviewService.getConversationHistory(sessionId);
+            List<VoiceInterviewMessageEntity> all = interviewService.getConversationHistory(sessionId);
+
+            // 分离 SUMMARY 行（压缩产生的滚动摘要），其余视为正常轮次
+            VoiceInterviewMessageEntity summaryRow = null;
+            List<VoiceInterviewMessageEntity> turns = new ArrayList<>();
+            for (VoiceInterviewMessageEntity msg : all) {
+                if (VoiceInterviewMessageEntity.MESSAGE_TYPE_SUMMARY.equals(msg.getMessageType())) {
+                    if (summaryRow == null) {
+                        summaryRow = msg;
+                    }
+                } else {
+                    turns.add(msg);
+                }
+            }
+
+            String cachedSummary = summaryRow != null
+                ? VoiceInterviewMessageEntity.trimToNull(summaryRow.getAiGeneratedText()) : null;
+            int coveredTurns = (summaryRow != null && summaryRow.getSequenceNum() != null)
+                ? Math.max(0, -summaryRow.getSequenceNum() - 1) : 0;
+
+            var compressed = voiceContextCompressor.compress(turns, cachedSummary, coveredTurns);
+
             List<String> history = new ArrayList<>();
-            String pendingAiQuestion = null;
+            if (compressed.summary() != null && !compressed.summary().isBlank()) {
+                history.add("【对话摘要】" + compressed.summary());
+            }
+            history.addAll(voiceContextCompressor.formatRecent(compressed.recent()));
 
-            for (VoiceInterviewMessageEntity msg : messages) {
-                String aiText = VoiceInterviewMessageEntity.trimToNull(msg.getAiGeneratedText());
-                String userText = VoiceInterviewMessageEntity.trimToNull(msg.getUserRecognizedText());
-
-                if (pendingAiQuestion != null) {
-                    history.add("面试官：" + pendingAiQuestion);
-                    pendingAiQuestion = null;
-                    if (userText != null) {
-                        history.add("候选人：" + userText);
-                    }
-                    if (aiText != null) {
-                        pendingAiQuestion = aiText;
-                    }
-                    continue;
-                }
-
-                if (aiText != null && userText != null) {
-                    history.add("面试官：" + aiText);
-                    history.add("候选人：" + userText);
-                } else if (aiText != null) {
-                    pendingAiQuestion = aiText;
-                } else if (userText != null) {
-                    history.add("候选人：" + userText);
+            // 摘要发生变化则持久化（UPSERT），保证断线重连后不重复生成
+            if (compressed.changed() && compressed.summary() != null && !compressed.summary().isBlank()) {
+                try {
+                    interviewService.saveSummaryRow(sessionId, compressed.summary(), compressed.coveredTurns());
+                } catch (Exception e) {
+                    log.warn("持久化上下文摘要失败（不影响本次应答），session {}", sessionId, e);
                 }
             }
-            if (pendingAiQuestion != null) {
-                history.add("面试官：" + pendingAiQuestion);
-            }
 
-            log.debug("Loaded {} messages from history for session {}", history.size(), sessionId);
+            log.debug("Loaded {} compressed history entries for session {}", history.size(), sessionId);
             return history;
         } catch (Exception e) {
             log.error("Error loading conversation history for session {}", sessionId, e);

--- a/app/src/main/java/interview/guide/modules/voiceinterview/model/VoiceInterviewMessageEntity.java
+++ b/app/src/main/java/interview/guide/modules/voiceinterview/model/VoiceInterviewMessageEntity.java
@@ -24,7 +24,14 @@ public class VoiceInterviewMessageEntity {
     private Long sessionId;
 
     @Column(name = "message_type", nullable = false)
-    private String messageType; // USER_SPEECH, AI_SPEECH, SYSTEM
+    private String messageType; // USER_SPEECH, AI_SPEECH, SYSTEM, SUMMARY
+
+    /**
+     * 对话摘要行类型。用于持久化上下文压缩产生的滚动摘要，
+     * 其 sequenceNum 取负值以在排序时位于普通轮次之前，
+     * 并通过 {@code -(sequenceNum + 1)} 编码已覆盖的轮次数（coveredTurns）。
+     */
+    public static final String MESSAGE_TYPE_SUMMARY = "SUMMARY";
 
     @Column(name = "phase")
     @Enumerated(EnumType.STRING)

--- a/app/src/main/java/interview/guide/modules/voiceinterview/repository/VoiceInterviewMessageRepository.java
+++ b/app/src/main/java/interview/guide/modules/voiceinterview/repository/VoiceInterviewMessageRepository.java
@@ -25,4 +25,9 @@ public interface VoiceInterviewMessageRepository extends JpaRepository<VoiceInte
     long countBySessionId(Long sessionId);
 
     void deleteBySessionId(Long sessionId);
+
+    Optional<VoiceInterviewMessageEntity> findFirstBySessionIdAndMessageTypeOrderBySequenceNumAsc(
+        Long sessionId, String messageType);
+
+    void deleteBySessionIdAndMessageType(Long sessionId, String messageType);
 }

--- a/app/src/main/java/interview/guide/modules/voiceinterview/service/VoiceInterviewService.java
+++ b/app/src/main/java/interview/guide/modules/voiceinterview/service/VoiceInterviewService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -299,6 +300,32 @@ public class VoiceInterviewService {
     public List<VoiceInterviewMessageEntity> getConversationHistory(String sessionId) {
         Long sessionIdLong = parseSessionId(sessionId);
         return messageRepository.findBySessionIdOrderBySequenceNumAsc(sessionIdLong);
+    }
+
+    /**
+     * 读取会话已持久化的上下文摘要行（message_type=SUMMARY）。无则空 Optional。
+     */
+    public Optional<VoiceInterviewMessageEntity> loadSummaryRow(String sessionId) {
+        Long sessionIdLong = parseSessionId(sessionId);
+        return messageRepository.findFirstBySessionIdAndMessageTypeOrderBySequenceNumAsc(
+            sessionIdLong, VoiceInterviewMessageEntity.MESSAGE_TYPE_SUMMARY);
+    }
+
+    /**
+     * 持久化上下文摘要行。先删除旧的 SUMMARY 行再写入新行（UPSERT 语义，避免重复行）。
+     * sequenceNum 取 {@code -(coveredTurns + 1)}：负值保证排序最前，且编码已覆盖轮次数。
+     */
+    public void saveSummaryRow(String sessionId, String summary, int coveredTurns) {
+        Long sessionIdLong = parseSessionId(sessionId);
+        messageRepository.deleteBySessionIdAndMessageType(
+            sessionIdLong, VoiceInterviewMessageEntity.MESSAGE_TYPE_SUMMARY);
+        VoiceInterviewMessageEntity row = VoiceInterviewMessageEntity.builder()
+            .sessionId(sessionIdLong)
+            .messageType(VoiceInterviewMessageEntity.MESSAGE_TYPE_SUMMARY)
+            .aiGeneratedText(summary)
+            .sequenceNum(-(coveredTurns + 1))
+            .build();
+        messageRepository.save(row);
     }
 
     /**

--- a/app/src/test/java/interview/guide/modules/voiceinterview/context/VoiceContextCompressorTest.java
+++ b/app/src/test/java/interview/guide/modules/voiceinterview/context/VoiceContextCompressorTest.java
@@ -1,0 +1,244 @@
+package interview.guide.modules.voiceinterview.context;
+
+import interview.guide.common.ai.LlmProviderRegistry;
+import interview.guide.modules.voiceinterview.config.VoiceInterviewProperties;
+import interview.guide.modules.voiceinterview.model.VoiceInterviewMessageEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * VoiceContextCompressor 单元测试。
+ *
+ * <p>覆盖：happy path（关闭/窗口/摘要触发）、边界（空输入、未达批次数）、
+ * 兼容性（关闭时格式化与改前一致）、LLM 摘要失败降级。
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VoiceContextCompressor 测试")
+class VoiceContextCompressorTest {
+
+    @Mock
+    private LlmProviderRegistry llmProviderRegistry;
+
+    private VoiceInterviewProperties properties;
+    private VoiceContextCompressor compressor;
+
+    @BeforeEach
+    void setUp() {
+        properties = new VoiceInterviewProperties();
+        properties.setContextCompression(new VoiceInterviewProperties.ContextCompressionConfig());
+        compressor = new VoiceContextCompressor(llmProviderRegistry, properties);
+    }
+
+    private VoiceInterviewMessageEntity turn(int seq, String ai, String user) {
+        return VoiceInterviewMessageEntity.builder()
+                .sequenceNum(seq)
+                .aiGeneratedText(ai)
+                .userRecognizedText(user)
+                .build();
+    }
+
+    private List<VoiceInterviewMessageEntity> turns(int n) {
+        List<VoiceInterviewMessageEntity> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(turn(i + 1, "面试官问题" + i, "候选人回答" + i));
+        }
+        return list;
+    }
+
+    @Nested
+    @DisplayName("happy path")
+    class HappyPath {
+
+        @Test
+        @DisplayName("关闭时返回全量，且与 formatRecent 等价（向后兼容）")
+        void disabledReturnsAll() {
+            properties.getContextCompression().setEnabled(false);
+            List<VoiceInterviewMessageEntity> all = turns(30);
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, null, 0);
+
+            assertNull(r.summary());
+            assertFalse(r.changed());
+            assertEquals(30, r.recent().size());
+            verify(llmProviderRegistry, never()).getPlainChatClient();
+        }
+
+        @Test
+        @DisplayName("WINDOW 模式：仅保留最近 windowSize 轮，不调用 LLM")
+        void windowMode() {
+            properties.getContextCompression().setEnabled(true);
+            properties.getContextCompression().setMode(VoiceInterviewProperties.Mode.WINDOW);
+            properties.getContextCompression().setWindowSize(20);
+            List<VoiceInterviewMessageEntity> all = turns(30);
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, null, 0);
+
+            assertNull(r.summary());
+            assertFalse(r.changed());
+            assertEquals(20, r.recent().size());
+            verify(llmProviderRegistry, never()).getPlainChatClient();
+        }
+
+        @Test
+        @DisplayName("SUMMARY 模式 + 达到批次数：触发增量摘要，changed=true")
+        void summaryTriggered() {
+            properties.getContextCompression().setEnabled(true);
+            properties.getContextCompression().setMode(VoiceInterviewProperties.Mode.SUMMARY);
+            properties.getContextCompression().setWindowSize(20);
+            properties.getContextCompression().setSummaryBatchSize(10);
+            // total=35 → earlyCount=15 >= 10 → 触发
+            List<VoiceInterviewMessageEntity> all = turns(35);
+            ChatClient chatClient = mockChatClient("合并后的摘要");
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, null, 0);
+
+            assertEquals("合并后的摘要", r.summary());
+            assertTrue(r.changed());
+            assertEquals(15, r.coveredTurns());
+            assertEquals(20, r.recent().size());
+            verify(llmProviderRegistry, times(1)).getPlainChatClient();
+        }
+    }
+
+    @Nested
+    @DisplayName("边界情况")
+    class Boundary {
+
+        @Test
+        @DisplayName("空输入：返回空，不报错")
+        void emptyInput() {
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(List.of(), null, 0);
+            assertNull(r.summary());
+            assertFalse(r.changed());
+            assertTrue(r.recent().isEmpty());
+        }
+
+        @Test
+        @DisplayName("未达窗口大小：返回全量，不压缩")
+        void belowWindow() {
+            properties.getContextCompression().setEnabled(true);
+            properties.getContextCompression().setMode(VoiceInterviewProperties.Mode.SUMMARY);
+            properties.getContextCompression().setWindowSize(20);
+            List<VoiceInterviewMessageEntity> all = turns(15);
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, null, 0);
+
+            assertNull(r.summary());
+            assertFalse(r.changed());
+            assertEquals(15, r.recent().size());
+        }
+
+        @Test
+        @DisplayName("SUMMARY 模式但未达批次数：不调用 LLM，recent 取窗口原文，summary 沿用缓存")
+        void summaryNotTriggered() {
+            properties.getContextCompression().setEnabled(true);
+            properties.getContextCompression().setMode(VoiceInterviewProperties.Mode.SUMMARY);
+            properties.getContextCompression().setWindowSize(20);
+            properties.getContextCompression().setSummaryBatchSize(10);
+            // total=25 → earlyCount=5 < 10 → 不触发
+            List<VoiceInterviewMessageEntity> all = turns(25);
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, "已有摘要", 0);
+
+            assertEquals("已有摘要", r.summary());
+            assertFalse(r.changed());
+            assertEquals(20, r.recent().size());
+            verify(llmProviderRegistry, never()).getPlainChatClient();
+        }
+
+        @Test
+        @DisplayName("SUMMARY 模式但 coveredTurns 大于 earlyCount（脏数据）：前置条件拦截，跳过摘要且不抛异常")
+        void dirtyCoveredTurnsSkipsSafely() {
+            properties.getContextCompression().setEnabled(true);
+            properties.getContextCompression().setMode(VoiceInterviewProperties.Mode.SUMMARY);
+            properties.getContextCompression().setWindowSize(20);
+            properties.getContextCompression().setSummaryBatchSize(10);
+            // total=35 → earlyCount=15，但传入脏数据 coveredTurns=20（> earlyCount）
+            List<VoiceInterviewMessageEntity> all = turns(35);
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, "已有摘要", 20);
+
+            // earlyCount > coveredTurns 前置条件拦住，subList 不会收到 from > to，不会抛 IllegalArgumentException
+            assertEquals("已有摘要", r.summary());
+            assertFalse(r.changed());
+            assertEquals(20, r.recent().size());
+            verify(llmProviderRegistry, never()).getPlainChatClient();
+        }
+    }
+
+    @Nested
+    @DisplayName("LLM 失败降级 & 兼容性")
+    class FailureAndCompat {
+
+        @Test
+        @DisplayName("摘要生成抛异常：降级沿用已有摘要，changed=false，不阻塞主链路")
+        void summaryFailureFallback() {
+            properties.getContextCompression().setEnabled(true);
+            properties.getContextCompression().setMode(VoiceInterviewProperties.Mode.SUMMARY);
+            properties.getContextCompression().setWindowSize(20);
+            properties.getContextCompression().setSummaryBatchSize(10);
+            List<VoiceInterviewMessageEntity> all = turns(35);
+            ChatClient chatClient = mock(ChatClient.class);
+            ChatClient.ChatClientRequestSpec spec = mock(ChatClient.ChatClientRequestSpec.class);
+            ChatClient.CallResponseSpec callSpec = mock(ChatClient.CallResponseSpec.class);
+            when(chatClient.prompt()).thenReturn(spec);
+            when(spec.user(anyString())).thenReturn(spec);
+            when(spec.call()).thenReturn(callSpec);
+            when(callSpec.content()).thenThrow(new RuntimeException("llm down"));
+            when(llmProviderRegistry.getPlainChatClient()).thenReturn(chatClient);
+
+            VoiceContextCompressor.CompressedHistory r = compressor.compress(all, "已有摘要", 0);
+
+            // 失败降级：summary 仍为已有摘要，且未标记 changed（避免无谓持久化）
+            assertEquals("已有摘要", r.summary());
+            assertFalse(r.changed());
+            assertEquals(20, r.recent().size());
+        }
+
+        @Test
+        @DisplayName("formatRecent 与原 getHistory 格式化一致：AI+用户成对、孤立 AI 暂挂起")
+        void formatRecentMatchesLegacy() {
+            List<VoiceInterviewMessageEntity> all = new ArrayList<>();
+            all.add(turn(1, "你介绍一下项目", "做过订单系统"));
+            all.add(turn(2, "用了什么数据库", null));      // 孤立 AI：挂起
+            all.add(turn(3, null, "MySQL 和 Redis"));        // 用户回答，配对上一条 AI
+            all.add(turn(4, "为什么选 Redis", "因为缓存热数据"));
+
+            List<String> formatted = compressor.formatRecent(all);
+
+            assertEquals(List.of(
+                    "面试官：你介绍一下项目",
+                    "候选人：做过订单系统",
+                    "面试官：用了什么数据库",
+                    "候选人：MySQL 和 Redis",
+                    "面试官：为什么选 Redis",
+                    "候选人：因为缓存热数据"
+            ), formatted);
+        }
+    }
+
+    private ChatClient mockChatClient(String content) {
+        ChatClient chatClient = mock(ChatClient.class);
+        ChatClient.ChatClientRequestSpec spec = mock(ChatClient.ChatClientRequestSpec.class);
+        ChatClient.CallResponseSpec callSpec = mock(ChatClient.CallResponseSpec.class);
+        when(chatClient.prompt()).thenReturn(spec);
+        when(spec.user(anyString())).thenReturn(spec);
+        when(spec.call()).thenReturn(callSpec);
+        when(callSpec.content()).thenReturn(content);
+        when(llmProviderRegistry.getPlainChatClient()).thenReturn(chatClient);
+        return chatClient;
+    }
+}

--- a/app/src/test/java/interview/guide/modules/voiceinterview/handler/VoiceInterviewWebSocketHandlerTest.java
+++ b/app/src/test/java/interview/guide/modules/voiceinterview/handler/VoiceInterviewWebSocketHandlerTest.java
@@ -3,6 +3,7 @@ package interview.guide.modules.voiceinterview.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.MeterRegistry;
 import interview.guide.modules.voiceinterview.config.VoiceInterviewProperties;
+import interview.guide.modules.voiceinterview.context.VoiceContextCompressor;
 import interview.guide.modules.voiceinterview.service.DashscopeLlmService;
 import interview.guide.modules.voiceinterview.service.QwenAsrService;
 import interview.guide.modules.voiceinterview.service.QwenTtsService;
@@ -37,6 +38,8 @@ class VoiceInterviewWebSocketHandlerTest {
   private DashscopeLlmService llmService;
   @Mock
   private VoiceInterviewService interviewService;
+  @Mock
+  private VoiceContextCompressor voiceContextCompressor;
   @Mock
   private ObjectProvider<MeterRegistry> meterRegistryProvider;
 
@@ -94,6 +97,7 @@ class VoiceInterviewWebSocketHandlerTest {
         ttsService,
         llmService,
         interviewService,
+        voiceContextCompressor,
         properties,
         meterRegistryProvider
     );


### PR DESCRIPTION
## Problem

语音面试链路的 `getHistory()` 每轮都会加载**全部**对话历史并原样拼入 LLM 的 prompt。在长会话（数十轮）场景下：

- prompt token 随轮次**无界增长**，存在上下文窗口超限（context overflow）与命中长度上限的风险；
- 每轮的 LLM 推理成本随历史长度线性上升，长面试的可扩展性与稳定性受限；
- 当前没有历史裁剪或摘要机制，无法在不破坏语义的前提下控制历史规模。

## Solution

引入 `VoiceContextCompressor`，将全量历史压缩为「**最近窗口原文 + 早期轮次滚动摘要**」两部分，提供三种模式：

- **NONE（默认）**：不压缩，返回全部历史 —— 完全向后兼容，旧部署行为不变。
- **WINDOW**：仅保留最近 `windowSize` 轮原文，更早轮次直接丢弃。
- **SUMMARY**：保留最近窗口原文 + 早期轮次的**增量滚动摘要**。

关键设计取舍：

1. **增量摘要而非每轮全量重摘**：仅在「尚未被摘要覆盖的早期轮次数量 ≥ `summaryBatchSize`」时才触发一次 LLM 摘要，把新增批次合并进已有摘要（`coveredTurns` 精确记录已覆盖轮次并持久化）。这把 LLM 摘要调用从「每轮一次」降到「每累积 `summaryBatchSize` 轮一次」，显著降低调用频次，也避免了全量重摘易丢失早期关键信息的问题。
2. **零表迁移持久化**：复用已有的 `voice_interview_messages` 表，用一条特殊 `SUMMARY` 消息行承载滚动摘要；其 `sequenceNum` 编码为 `-(coveredTurns + 1)`，主链路解码为 `-(sequenceNum + 1)`。无需新增表或字段迁移，降低运维与评审成本。
3. **使用 `getPlainChatClient()` 而非 `getDefaultChatClient()`**：摘要是纯文本压缩任务，不应携带 `SkillsTool`（面试素材工具，与摘要无关），也不应让 `MessageChatMemoryAdvisor` 再次注入完整历史（那样会抵消压缩收益，甚至造成混淆）。
4. **失败降级不阻塞主链路**：摘要生成失败（`try-catch` 内）或 `SUMMARY` 行缺失/损坏时，均降级沿用已有摘要或返回全量，面试主链路不会被压缩逻辑阻塞。

## Changes

- **新增 `VoiceInterviewProperties.ContextCompressionConfig`**：`enabled`、`mode`、`windowSize`、`summaryBatchSize` 配置项。
- **新增 `VoiceInterviewMessageEntity.MESSAGE_TYPE_SUMMARY`** 常量，标识摘要行。
- **`VoiceInterviewMessageRepository`**：新增加载 / 删除 `SUMMARY` 行的派生查询。
- **`VoiceInterviewService`**：新增 `loadSummaryRow` / `saveSummaryRow`（UPSERT，`sequenceNum` 编码为 `-(coveredTurns+1)`）；`trimToNull` 防御空串。
- **新增 `VoiceContextCompressor`**：核心压缩器，支持 NONE / WINDOW / SUMMARY 三模式与增量摘要；`formatRecent` 与原 `getHistory` 格式化逻辑保持一致。
- **`LlmProviderRegistry`**：新增无参 `getPlainChatClient()` 重载（复用 `resolveDefaultChatProviderId`）。
- **`VoiceInterviewWebSocketHandler.getHistory` 重写**：分离 `SUMMARY` 行 → 调用压缩器 → 前置【对话摘要】 → 仅当 `changed` 时持久化。返回类型 `List<String>` 不变，调用方（`triggerLlmResponse`、`triggerOpeningQuestionIfNeeded`）无需改动。
- **测试**：新增 `VoiceContextCompressorTest`（11 个用例）；同步 `VoiceInterviewWebSocketHandlerTest` 构造器以适配新增依赖。

## Testing

**如何验证：**

- 单元测试：

  ```
  ./gradlew :app:test --tests "*VoiceContextCompressor*" --tests "*VoiceInterviewWebSocketHandler*"
  ```

- 集成验证：配置 `mode=SUMMARY, windowSize=20, summaryBatchSize=15`，跑一段 >35 轮的会话，确认发给 LLM 的 prompt 中只有「最近 20 轮原文 + 一条滚动摘要」。

- 兼容性验证：不配置或 `mode=NONE` 时，行为与改动前完全一致（返回全量历史）。

**测试覆盖场景：**

- 正常路径：NONE 返回全量；WINDOW 裁剪早期轮次；SUMMARY 在达到 `summaryBatchSize` 时触发增量摘要。
- 边界：
  - `earlyCount == coveredTurns` 时不触发摘要；
  - 上游脏数据导致 `coveredTurns > earlyCount` 时，`earlyCount > coveredTurns` 前置保护生效，不抛 `subList(from>to)` 异常、不调用 LLM、`changed=false`。
- 失败与兼容：
  - LLM 摘要异常 → 降级沿用旧摘要；
  - `SUMMARY` 行缺失 / 损坏 → `getHistory` 仍可正常工作。

共 **11 个单元测试，全部通过**（含 `VoiceContextCompressorTest` 9 例 + `VoiceInterviewWebSocketHandlerTest` 2 例）。

## Notes for Reviewer

**重点设计决策（请重点关注）：**

1. **`getPlainChatClient()` 替代 `getDefaultChatClient()`**：摘要调用刻意剥离 `SkillsTool` 与 `MemoryAdvisor`，避免无关 advisor 干扰纯压缩任务。来自外部代码审查建议，已采纳。
2. **`earlyCount > coveredTurns` 前置保护**：防御上游脏数据（如损坏的 `SUMMARY` 行使 `coveredTurns` 异常偏大）引发 `subList(from>to)` 抛 `IllegalArgumentException`。同样是审查建议，已作为防御性代码采纳。
3. **零迁移 `SUMMARY` 行设计**：复用消息表，`sequenceNum = -(coveredTurns+1)` 编码覆盖轮次，无需 DDL 迁移。

**有意为之：**

- 摘要失败或被压缩逻辑异常**不阻塞**面试主链路（降级 + `try-catch`）。
- `compress()` 在 `turns.size() <= windowSize` 时直接返回全量，保证向后兼容。

**后续优化（不在本 PR 范围）：**

- `getConversationHistory` 当前全量加载、未做分页限制；长会话可引入分页 / 游标查询。可作为后续 PR 的增强点，也适合在面试中作为「后续改进」主动陈述。
- 本分支基于上游 `master`（上游 toolchain 为 Java 25 + 预览特性）；本地为 Java 21 临时降版本跑通测试，PR 本身**不改动任何 build 配置**。