### PR TITLE
fix(面试): 防止页面刷新时重复生成面试题

### DIFF
--- a/app/src/main/java/interview/guide/modules/interview/model/CreateInterviewRequest.java
+++ b/app/src/main/java/interview/guide/modules/interview/model/CreateInterviewRequest.java
@@ -30,5 +30,7 @@ public record CreateInterviewRequest(
 
     List<CategoryDTO> customCategories,   // 自定义面试的分类（JD 解析结果）
 
-    String jdText                          // JD 原文（自定义面试时作为出题依据）
+    String jdText,                         // JD 原文（自定义面试时作为出题依据）
+
+    String requestId                       // 创建请求幂等键，刷新/重试时复用同一会话
 ) {}

--- a/app/src/main/java/interview/guide/modules/interview/service/InterviewSessionService.java
+++ b/app/src/main/java/interview/guide/modules/interview/service/InterviewSessionService.java
@@ -7,6 +7,7 @@ import interview.guide.common.exception.ErrorCode;
 import interview.guide.common.model.AsyncTaskStatus;
 import interview.guide.infrastructure.redis.InterviewSessionCache;
 import interview.guide.infrastructure.redis.InterviewSessionCache.CachedSession;
+import interview.guide.infrastructure.redis.RedisService;
 import interview.guide.modules.interview.listener.EvaluateStreamProducer;
 import interview.guide.modules.interview.model.CreateInterviewRequest;
 import interview.guide.modules.interview.model.HistoricalQuestion;
@@ -25,10 +26,12 @@ import org.springframework.stereotype.Service;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 面试会话管理服务
@@ -39,6 +42,10 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class InterviewSessionService {
 
+    private static final String CREATE_LOCK_PREFIX = "interview:create:";
+    private static final String CREATE_RESULT_PREFIX = "interview:create:result:";
+    private static final Duration CREATE_RESULT_TTL = Duration.ofDays(1);
+
     private final InterviewQuestionService questionService;
     private final AnswerEvaluationService evaluationService;
     private final InterviewPersistenceService persistenceService;
@@ -46,6 +53,7 @@ public class InterviewSessionService {
     private final ObjectMapper objectMapper;
     private final EvaluateStreamProducer evaluateStreamProducer;
     private final LlmProviderRegistry llmProviderRegistry;
+    private final RedisService redisService;
 
     /**
      * 创建新的面试会话
@@ -53,6 +61,34 @@ public class InterviewSessionService {
      * 前端应该先调用 findUnfinishedSession 检查，或者使用 forceCreate 参数强制创建
      */
     public InterviewSessionDTO createSession(CreateInterviewRequest request) {
+        String requestId = normalizeRequestId(request.requestId());
+        if (requestId == null) {
+            return createSessionInternal(request);
+        }
+
+        return redisService.executeWithLock(
+            CREATE_LOCK_PREFIX + requestId,
+            185,
+            600,
+            TimeUnit.SECONDS,
+            () -> createIdempotentSession(request, requestId)
+        );
+    }
+
+    private InterviewSessionDTO createIdempotentSession(CreateInterviewRequest request, String requestId) {
+        String resultKey = CREATE_RESULT_PREFIX + requestId;
+        String cachedSessionId = redisService.get(resultKey);
+        if (cachedSessionId != null) {
+            log.info("复用缓存中的幂等创建请求: requestId={}, sessionId={}", requestId, cachedSessionId);
+            return getSession(cachedSessionId);
+        }
+
+        InterviewSessionDTO created = createSessionInternal(request);
+        redisService.set(resultKey, created.sessionId(), CREATE_RESULT_TTL);
+        return created;
+    }
+
+    private InterviewSessionDTO createSessionInternal(CreateInterviewRequest request) {
         // 如果指定了resumeId且未强制创建，检查是否有未完成的会话
         if (request.resumeId() != null && !Boolean.TRUE.equals(request.forceCreate())) {
             Optional<InterviewSessionDTO> unfinishedOpt = findUnfinishedSession(request.resumeId());
@@ -112,6 +148,18 @@ public class InterviewSessionService {
             questions,
             SessionStatus.CREATED
         );
+    }
+
+    private String normalizeRequestId(String requestId) {
+        if (requestId == null || requestId.isBlank()) {
+            return null;
+        }
+
+        String normalized = requestId.trim();
+        if (!normalized.matches("[A-Za-z0-9_-]{8,64}")) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "requestId 格式不正确");
+        }
+        return normalized;
     }
 
     /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,7 +97,11 @@ interface InterviewEntryState {
 
 // 模拟面试包装器
 function InterviewWrapper() {
-  const { resumeId } = useParams<{ resumeId: string }>();
+  const { resumeId, requestId, activeSessionId } = useParams<{
+    resumeId: string;
+    requestId: string;
+    activeSessionId: string;
+  }>();
   const navigate = useNavigate();
   const location = useLocation();
   const entryState = (location.state as InterviewEntryState | undefined) ?? {};
@@ -140,6 +144,20 @@ function InterviewWrapper() {
     navigate('/interviews');
   };
 
+  const handleSessionCreated = (sessionId: string) => {
+    navigate(`/interview/session/${sessionId}`, { replace: true, state: entryState });
+  };
+
+  if (!requestId && !activeSessionId && !entryState.sessionIdToResume) {
+    return (
+      <Navigate
+        to={`/interview/create/${crypto.randomUUID()}`}
+        replace
+        state={{ ...entryState, resumeId: effectiveResumeId }}
+      />
+    );
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -155,9 +173,11 @@ function InterviewWrapper() {
     <Interview
       resumeText={resumeText}
       resumeId={effectiveResumeId}
-      sessionIdToResume={entryState.sessionIdToResume}
+      sessionIdToResume={activeSessionId ?? entryState.sessionIdToResume}
+      requestId={requestId}
       initialConfig={entryState.interviewConfig}
       onBack={handleBack}
+      onSessionCreated={handleSessionCreated}
       onInterviewComplete={handleInterviewComplete}
     />
   );
@@ -192,6 +212,12 @@ function App() {
 
             {/* 模拟面试（通用入口） */}
             <Route path="interview" element={<InterviewWrapper />} />
+
+            {/* 创建中的文本面试，请求 ID 用于刷新幂等 */}
+            <Route path="interview/create/:requestId" element={<InterviewWrapper />} />
+
+            {/* 进行中的文本面试，刷新时按会话 ID 恢复 */}
+            <Route path="interview/session/:activeSessionId" element={<InterviewWrapper />} />
 
             {/* 模拟面试 */}
             <Route path="interview/:resumeId" element={<InterviewWrapper />} />
@@ -242,7 +268,7 @@ function InterviewHistoryWrapper() {
   };
 
   const handleContinueInterview = (sessionId: string) => {
-    navigate('/interview', { state: { sessionIdToResume: sessionId } });
+    navigate(`/interview/session/${sessionId}`);
   };
 
   return <InterviewHistoryPage onBack={handleBack} onViewInterview={handleViewInterview} onRestartInterview={handleRestartInterview} onContinueInterview={handleContinueInterview} />;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -45,7 +45,7 @@ export default function Layout() {
   const handleInterviewStart = (config: UnifiedInterviewConfig) => {
     setInterviewModalPreset(null);
     if (config.mode === 'text') {
-      navigate('/interview', {
+      navigate(`/interview/create/${crypto.randomUUID()}`, {
         state: {
           resumeId: config.resumeId,
           interviewConfig: {

--- a/frontend/src/pages/InterviewHubPage.tsx
+++ b/frontend/src/pages/InterviewHubPage.tsx
@@ -97,7 +97,7 @@ export default function InterviewHubPage() {
     }
 
     if (config.mode === 'text') {
-      navigate('/interview', {
+      navigate(`/interview/create/${crypto.randomUUID()}`, {
         state: {
           resumeId: config.resumeId,
           interviewConfig: {

--- a/frontend/src/pages/InterviewPage.tsx
+++ b/frontend/src/pages/InterviewPage.tsx
@@ -20,6 +20,7 @@ interface InterviewProps {
   resumeText: string;
   resumeId?: number;
   sessionIdToResume?: string;
+  requestId?: string;
   initialConfig?: {
     questionCount?: number;
     llmProvider?: string;
@@ -29,6 +30,7 @@ interface InterviewProps {
     jdText?: string;
   };
   onBack: () => void;
+  onSessionCreated: (sessionId: string) => void;
   onInterviewComplete: () => void;
 }
 
@@ -36,8 +38,10 @@ export default function Interview({
   resumeText,
   resumeId,
   sessionIdToResume,
+  requestId,
   initialConfig,
   onBack,
+  onSessionCreated,
   onInterviewComplete,
 }: InterviewProps) {
   const [session, setSession] = useState<InterviewSession | null>(null);
@@ -85,9 +89,11 @@ export default function Interview({
         difficulty,
         customCategories: skillId === CUSTOM_SKILL_ID ? customCategories : undefined,
         jdText: skillId === CUSTOM_SKILL_ID ? jdText : undefined,
+        requestId,
       });
 
       initSession(newSession);
+      onSessionCreated(newSession.sessionId);
     } catch (err) {
       setError('创建面试失败，请重试');
       console.error(err);

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -31,6 +31,7 @@ export interface CreateInterviewRequest {
   difficulty?: string;
   customCategories?: CategoryDTO[];
   jdText?: string;
+  requestId?: string;
 }
 
 export interface SubmitAnswerRequest {


### PR DESCRIPTION
## 问题说明

生成面试题过程中刷新页面，会再次调用创建面试接口，导致重复生成面试题和额外的面试记录。

## 修改内容

- 为创建面试请求增加 `requestId`
- 将 `requestId` 保存在创建页面 URL 中，刷新后继续使用同一个请求标识
- 使用 Redis 分布式锁避免相同请求被重复执行
- 缓存 `requestId` 与 `sessionId` 的映射关系
- 生成成功后将 URL 替换为会话地址
- 刷新进行中的面试时，根据 `sessionId` 恢复已有会话

## 修改效果

- 生成过程中刷新页面不会重复生成题目
- 网络重试不会创建额外的面试会话
- 面试创建成功后刷新页面可以恢复当前会话
- 不涉及数据库表结构变更

## 验证情况

代码已完成，暂未执行自动化测试，等待手动验证。